### PR TITLE
Update lightbox.js

### DIFF
--- a/plugins/opTimelinePlugin/web/js/lightbox.js
+++ b/plugins/opTimelinePlugin/web/js/lightbox.js
@@ -48,8 +48,8 @@ lightbox = new Lightbox options
   LightboxOptions = (function() {
 
     function LightboxOptions() {
-      this.fileLoadingImage = '/opTimelinePlugin/images/loading.gif';
-      this.fileCloseImage = '/opTimelinePlugin/images/close.png';
+      this.fileLoadingImage = '../../img//loading.gif';
+      this.fileCloseImage = '../../img//close.png';
       this.resizeDuration = 700;
       this.fadeDuration = 500;
       this.labelImage = "Image";


### PR DESCRIPTION
timelineのｌｉｇｈｔｂｏｘの画像が、この

> ・Bug（バグ） #3656: スマートフォンからの画面遷移がサブディレクトリを考慮していない - opDiaryPlugin - OpenPNE Issue Tracking System ： 
> ・OpenPNE公式SNS ： http://goo.gl/OabrjR
> ・fixes disregard of relative url access by smartphone. (refs #3656) · amashigeseiji/opDiaryPlugin@22c0410 ： https://goo.gl/Y1Buz5
> https://goo.gl/TC89Oj

案件に似たようにサブディレクトリを考慮してないようなので、
ドメイン配下にイメージフォルダを作ってここに格納しました。